### PR TITLE
Add brand logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="assets/logo.svg" alt="Harbor logo" width="120" height="120">
+</p>
+
 # Harbor ⚓
 
 Local desktop app framework - web frontends connecting to gunicorn/nginx over Unix sockets (Linux/macOS) or named pipes (Windows).

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,9 @@
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <line x1="24" y1="34" x2="76" y2="34" stroke="#808078" stroke-width="3" stroke-linecap="round"/>
+  <path d="M24 34 Q24 70 50 70 Q76 70 76 34" fill="none" stroke="#808078" stroke-width="3" stroke-linecap="round"/>
+  <path d="M27 46 Q50 60 73 46" fill="none" stroke="#808078" stroke-width="2.5" opacity="0.6"/>
+  <path d="M29 56 Q50 66 71 56" fill="none" stroke="#808078" stroke-width="2.5" opacity="0.45"/>
+  <line x1="38" y1="69" x2="34" y2="82" stroke="#808078" stroke-width="3" stroke-linecap="round"/>
+  <line x1="62" y1="69" x2="66" y2="82" stroke="#808078" stroke-width="3" stroke-linecap="round"/>
+  <line x1="26" y1="84" x2="74" y2="84" stroke="#808078" stroke-width="4" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
Adds the canonical project logo (`assets/logo.svg`) consistent with skepticalengineering.com and shows it at the top of the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)